### PR TITLE
Start without db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_script:
 script:
   - mkdir -p phpunit/logs
   - vendor/bin/phpunit --debug --stop-on-error --stop-on-failure
+  - chmod 777 phpunit/logs/clover.xml
 
 after_success:
  - php vendor/bin/coveralls -v

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Oxrun
 
 [![Build Status](https://travis-ci.org/marcharding/oxrun.svg)](https://travis-ci.org/marcharding/oxrun)
-[![Coverage Status](https://coveralls.io/repos/marcharding/oxrun/badge.svg?branch=master)](https://coveralls.io/r/marcharding/oxrun?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/marcharding/oxrun/badge.svg?branch=master)](https://coveralls.io/github/marcharding/oxrun?branch=master)
 
 Oxrun provides a cli toolset for the OXID eShop Community Edition.
 

--- a/src/Oxrun/Application.php
+++ b/src/Oxrun/Application.php
@@ -63,12 +63,12 @@ class Application extends BaseApplication
      * @param bool $skipViews Add 'blSkipViewUsage' to OXIDs config.
      * @return bool
      */
-    public function bootstrapOxid($skipViews = false)
+    public function bootstrapOxid()
     {
         $input = new ArgvInput();
         if($input->getParameterOption('--shopDir')) {
             $oxBootstrap = $input->getParameterOption('--shopDir'). '/bootstrap.php';
-            if( $this->checkBootstrapOxidInclude( $oxBootstrap, $skipViews ) === true ) {
+            if( $this->checkBootstrapOxidInclude( $oxBootstrap ) === true ) {
                 return true;
             }
             return false;
@@ -78,7 +78,7 @@ class Application extends BaseApplication
         $currentWorkingDirectory = getcwd();
         do {
             $oxBootstrap = $currentWorkingDirectory . '/bootstrap.php';
-            if( $this->checkBootstrapOxidInclude( $oxBootstrap, $skipViews ) === true ) {
+            if( $this->checkBootstrapOxidInclude( $oxBootstrap ) === true ) {
                 return true;
                 break;
             }
@@ -94,16 +94,12 @@ class Application extends BaseApplication
      * @param bool $skipViews Add 'blSkipViewUsage' to OXIDs config.
      * @return bool
      */
-    public function checkBootstrapOxidInclude($oxBootstrap, $skipViews = false)
+    public function checkBootstrapOxidInclude($oxBootstrap)
     {
         if (is_file($oxBootstrap)) {
             // is it the oxid bootstrap.php?
             if (strpos(file_get_contents($oxBootstrap), 'OX_BASE_PATH') !== false) {
                 $this->shopDir = dirname($oxBootstrap);
-
-                if ($skipViews) {
-                    $this->applyOxRunConfig(['blSkipViewUsage' => true]);
-                }
 
                 require_once $oxBootstrap;
 
@@ -116,9 +112,6 @@ class Application extends BaseApplication
                 // we must call this once, otherwise there are no modules visible in a fresh shop
                 $oModuleList = oxNew("oxModuleList");
                 $oModuleList->getModulesFromDir(\oxRegistry::getConfig()->getModulesDir());
-
-                $this->removeOxRunConfig();
-
                 return true;
             }
         }
@@ -126,39 +119,6 @@ class Application extends BaseApplication
         return false;
     }
 
-    /**
-     * Adds custom Oxrun configuration to config.inc.php (if exists and not already done).
-     *
-     * @param array $config
-     */
-    protected function applyOxRunConfig(array $config = [])
-    {
-        if (null === $this->oxidConfigContent) {
-            $oxConfigInc    = "{$this->shopDir}/config.inc.php";
-            $oxConfigExists = file_exists("{$this->shopDir}/config.inc.php");
-
-            if ($oxConfigExists) {
-                $this->oxidConfigContent = file_get_contents("{$this->shopDir}/config.inc.php");
-                $newConfigContent = $this->oxidConfigContent;
-                foreach ($config as $configKey => $configValue) {
-                    $newConfigContent .= "\n\$this->{$configKey} = " . var_export($configValue, true);
-                }
-
-                file_put_contents($oxConfigInc, $newConfigContent);
-            }
-
-        }
-    }
-
-    /**
-     * Removes custom Oxrun configuration from config.inc.php.
-     */
-    protected function removeOxRunConfig()
-    {
-        if (null !== $this->oxidConfigContent) {
-            file_put_contents("{$this->shopDir}/config.inc.php", $this->oxidConfigContent);
-        }
-    }
 
     /**
      * @return string

--- a/src/Oxrun/Application.php
+++ b/src/Oxrun/Application.php
@@ -109,9 +109,6 @@ class Application extends BaseApplication
                     $this->autoloader->register(true);
                 }
 
-                // we must call this once, otherwise there are no modules visible in a fresh shop
-                $oModuleList = oxNew("oxModuleList");
-                $oModuleList->getModulesFromDir(\oxRegistry::getConfig()->getModulesDir());
                 return true;
             }
         }

--- a/src/Oxrun/Command/Custom/ListCommand.php
+++ b/src/Oxrun/Command/Custom/ListCommand.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Created for oxrun
+ * Author: Tobias Matthaiou <matthaiou@tobimat.eu>
+ */
+
+namespace Oxrun\Command\Custom;
+
+use Oxrun\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListCommand extends \Symfony\Component\Console\Command\ListCommand
+{
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        parent::execute($input, $output);
+
+        $this->checkDatabase($this->getApplication(), $output);
+    }
+
+    /**
+     * @param $application
+     * @param OutputInterface $output
+     */
+    protected function checkDatabase(Application $application, OutputInterface $output)
+    {
+        if ($application->bootstrapOxid(false) && $application->canConnectToDB() == false) {
+            $output->writeln('');
+            $output->writeln('<error>  Can\'t connect to Database. Most of the Commands are disabled </error>');
+            $output->writeln('<error>  Error Message: ' . $application->getDatenbaseConnection()->getLastErrorMsg() . '</error>');
+        }
+    }
+}

--- a/src/Oxrun/Command/Module/ActivateCommand.php
+++ b/src/Oxrun/Command/Module/ActivateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Oxrun\Command\Module;
 
+use Oxrun\Traits\ModuleListCheckTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ActivateCommand extends Command
 {
+    use ModuleListCheckTrait;
 
     /**
      * Configures the current command.
@@ -33,6 +35,8 @@ class ActivateCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->checkModulelist();
+
         if (version_compare($this->getApplication()->getOxidVersion(), '4.9.0') >= 0) {
             $this->executeVersion490($input, $output);
         } else {

--- a/src/Oxrun/Command/Module/DeactivateCommand.php
+++ b/src/Oxrun/Command/Module/DeactivateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Oxrun\Command\Module;
 
+use Oxrun\Traits\ModuleListCheckTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DeactivateCommand extends Command
 {
+    use ModuleListCheckTrait;
 
     /**
      * Configures the current command.
@@ -33,6 +35,8 @@ class DeactivateCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->checkModulelist();
+
         if (version_compare($this->getApplication()->getOxidVersion(), '4.9.0') >= 0) {
             $this->executeVersion490($input, $output);
         } else {

--- a/src/Oxrun/Command/Module/ListCommand.php
+++ b/src/Oxrun/Command/Module/ListCommand.php
@@ -2,6 +2,7 @@
 
 namespace Oxrun\Command\Module;
 
+use Oxrun\Traits\ModuleListCheckTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ListCommand extends Command
 {
+    use ModuleListCheckTrait;
 
     /**
      * Configures the current command.
@@ -32,6 +34,8 @@ class ListCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->checkModulelist();
+
         $oxModuleList = oxNew('oxModuleList');
 
         $activeModules = array_keys($oxModuleList->getActiveModuleInfo());

--- a/src/Oxrun/Command/Views/UpdateCommand.php
+++ b/src/Oxrun/Command/Views/UpdateCommand.php
@@ -49,7 +49,7 @@ class UpdateCommand extends Command
     {
         /** @var \Oxrun\Application $application */
         $application = $this->getApplication();
-        return $application->bootstrapOxid(true);
+        return $application->bootstrapOxid();
     }
 
 }

--- a/src/Oxrun/Helper/DatenbaseConnection.php
+++ b/src/Oxrun/Helper/DatenbaseConnection.php
@@ -132,7 +132,12 @@ class DatenbaseConnection
     public function canConnectToMysql()
     {
         if ($this->PDO === null) {
-            $this->inspectAccessData();
+            try {
+                $this->inspectAccessData();
+            } catch (\LogicException $e) {
+                $this->lastErrorMsg = $e->getMessage();
+                return false;
+            }
 
             $dsn = sprintf('mysql:dbname=%s;host=%s;port=%s', $this->database, $this->host, $this->port);
 
@@ -169,7 +174,7 @@ class DatenbaseConnection
     protected function inspectAccessData()
     {
         if ($this->host == '' || $this->port == false || $this->user == '') {
-            throw new \LogicException('Param host, port or user are empty');
+            throw new \LogicException('The config param DB::host, DB::port or DB::user are empty');
         }
     }
 

--- a/src/Oxrun/Helper/DatenbaseConnection.php
+++ b/src/Oxrun/Helper/DatenbaseConnection.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Created for oxrun
+ * Author: Tobias Matthaiou <matthaiou@tobimat.eu>
+ */
+
+
+namespace Oxrun\Helper;
+
+/**
+ * Class DatenbaseConnection
+ *
+ * Connect direct to Database
+ *
+ * @package Oxrun\Helper
+ */
+class DatenbaseConnection
+{
+
+    /**
+     * @var string
+     */
+    protected $lastErrorMsg = '';
+
+    /**
+     * @var string
+     */
+    protected $host = '';
+
+    /**
+     * @var int
+     */
+    protected $port = 3306;
+
+    /**
+     * @var string
+     */
+    protected $user = '';
+
+    /**
+     * @var string
+     */
+    protected $pass = '';
+
+    /**
+     * @var string
+     */
+    protected $database = '';
+
+    /**
+     * @var \PDO
+     */
+    protected $PDO = null;
+
+    /**
+     * @param string $host
+     * @return DatenbaseConnection
+     */
+    public function setHost($host)
+    {
+        $this->host = $host;
+
+        if (preg_match('/^([^:]+):(\d+)$/', $host, $matchs)) {
+            $this->host = $matchs[1];
+            $this->setPort($matchs[2]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * @param int $port
+     * @return DatenbaseConnection
+     */
+    public function setPort($port)
+    {
+        $this->port = $port;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPort()
+    {
+        return $this->port;
+    }
+
+    /**
+     * @param string $user
+     * @return DatenbaseConnection
+     */
+    public function setUser($user)
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    /**
+     * @param string $pass
+     * @return DatenbaseConnection
+     */
+    public function setPass($pass)
+    {
+        $this->pass = $pass;
+        return $this;
+    }
+
+    /**
+     * @param string $database
+     * @return DatenbaseConnection
+     */
+    public function setDatabase($database)
+    {
+        $this->database = $database;
+        return $this;
+    }
+
+    /**
+     * Checks if can connect to a mysql DB
+     *
+     * @return bool
+     */
+    public function canConnectToMysql()
+    {
+        if ($this->PDO === null) {
+            $this->inspectAccessData();
+
+            $dsn = sprintf('mysql:dbname=%s;host=%s;port=%s', $this->database, $this->host, $this->port);
+
+            try {
+                $this->PDO = new \PDO($dsn, $this->user, $this->pass);
+            } catch (\Exception $e) {
+                $this->lastErrorMsg = $e->getMessage();
+                return false;
+            }
+        }
+
+        return is_object($this->PDO);
+    }
+
+    /**
+     * Execute a SQL Command
+     *
+     * @param $SQL
+     *
+     * @return bool
+     */
+    public function execute($SQL, $params = null)
+    {
+        if ($this->canConnectToMysql()) {
+            $PDOStatement = $this->PDO->prepare($SQL);
+            $result = $PDOStatement->execute($params);
+            $PDOStatement->closeCursor();
+            return $result;
+        }
+
+        return false;
+    }
+
+    protected function inspectAccessData()
+    {
+        if ($this->host == '' || $this->port == false || $this->user == '') {
+            throw new \LogicException('Param host, port or user are empty');
+        }
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLastErrorMsg()
+    {
+        return $this->lastErrorMsg;
+    }
+}

--- a/src/Oxrun/Traits/ModuleListCheckTrait.php
+++ b/src/Oxrun/Traits/ModuleListCheckTrait.php
@@ -19,11 +19,8 @@ trait ModuleListCheckTrait
      */
     protected function checkModulelist()
     {
-        $aModuleList = \oxRegistry::getConfig()->getConfigParam('aModulePaths');
-        if (is_array($aModuleList) == false || count($aModuleList) == 0) {
-            // we must call this once, otherwise there are no modules visible in a fresh shop
-            $oModuleList = oxNew("oxModuleList");
-            $oModuleList->getModulesFromDir(\oxRegistry::getConfig()->getModulesDir());
-        }
+        // we must call this once, otherwise there are no modules visible in a fresh shop
+        $oModuleList = oxNew("oxModuleList");
+        $oModuleList->getModulesFromDir(\oxRegistry::getConfig()->getModulesDir());
     }
 }

--- a/src/Oxrun/Traits/ModuleListCheckTrait.php
+++ b/src/Oxrun/Traits/ModuleListCheckTrait.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Created for oxrun
+ * Author: Tobias Matthaiou <matthaiou@tobimat.eu>
+ */
+
+
+namespace Oxrun\Traits;
+
+/**
+ * Class ModuleListCheck
+ * @package OxrunTrait
+ */
+trait ModuleListCheckTrait
+{
+
+    /**
+     * Check if we have Modulelist, else create new.
+     */
+    protected function checkModulelist()
+    {
+        $aModuleList = \oxRegistry::getConfig()->getConfigParam('aModulePaths');
+        if (is_array($aModuleList) == false || count($aModuleList) == 0) {
+            // we must call this once, otherwise there are no modules visible in a fresh shop
+            $oModuleList = oxNew("oxModuleList");
+            $oModuleList->getModulesFromDir(\oxRegistry::getConfig()->getModulesDir());
+        }
+    }
+}

--- a/tests/Oxrun/Helper/DatenbaseConnectionTest.php
+++ b/tests/Oxrun/Helper/DatenbaseConnectionTest.php
@@ -48,6 +48,26 @@ class DatenbaseConnectionTest extends \PHPUnit_Framework_TestCase
         self::assertContains("Unknown database 'oxid_unbekannt'", $this->testSubject->getLastErrorMsg());
     }
 
+    /**
+     * @dataProvider getEmptyConfigs
+     */
+    public function testHasEmptyConfig($func, $value)
+    {
+        $this->testSubject->$func($value);
+
+        self::assertFalse($this->testSubject->canConnectToMysql());
+        self::assertContains("are empty", $this->testSubject->getLastErrorMsg());
+    }
+
+    public function getEmptyConfigs()
+    {
+        return [
+            'No Host Config' => ['func'=>'setHost', 'value' => ''],
+            'No Port Config' => ['func'=>'setPort', 'value' => 0],
+            'No User Config' => ['func'=>'setUser', 'value' => ''],
+        ];
+    }
+
     public function testCanConnected()
     {
         self::assertTrue($this->testSubject->canConnectToMysql());

--- a/tests/Oxrun/Helper/DatenbaseConnectionTest.php
+++ b/tests/Oxrun/Helper/DatenbaseConnectionTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Created for oxrun
+ * Author: Tobias Matthaiou <matthaiou@tobimat.eu>
+ */
+
+
+namespace Oxrun\Helper;
+
+
+class DatenbaseConnectionTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var DatenbaseConnection
+     */
+    protected $testSubject;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        $datenbaseConnection = new DatenbaseConnection();
+        $datenbaseConnection
+            ->setHost('127.0.0.1')
+            ->setPort('3306')
+            ->setUser('root')
+            ->setPass('')
+            ->setDatabase('oxid');
+
+        $this->testSubject = $datenbaseConnection;
+    }
+
+    public function testCanParseHostPort()
+    {
+        $this->testSubject->setHost('127.0.0.1:3336');
+
+        self::assertEquals('127.0.0.1', $this->testSubject->getHost());
+        self::assertEquals(3336,        $this->testSubject->getPort());
+    }
+
+    public function testHasNotConnected()
+    {
+        $this->testSubject->setDatabase('oxid_unbekannt');
+
+        self::assertFalse($this->testSubject->canConnectToMysql());
+        self::assertContains("Unknown database 'oxid_unbekannt'", $this->testSubject->getLastErrorMsg());
+    }
+
+    public function testCanConnected()
+    {
+        self::assertTrue($this->testSubject->canConnectToMysql());
+    }
+
+    public function testExecuteSelect()
+    {
+        $result = $this->testSubject->execute('SELECT OXID FROM oxconfig');
+        self::assertTrue($result);
+    }
+
+    public function testExecuteSelectWithParams()
+    {
+        $SQL = 'SELECT OXID FROM oxconfig WHERE OXVARNAME LIKE ?';
+
+        $result = $this->testSubject->execute($SQL, ['%modules%']);
+        self::assertTrue($result);
+    }
+}


### PR DESCRIPTION
Das Tool stürzte ab, wenn keine DB Verbindung gestartet werden konnte oder es Fehler gab. Meistens reichte es aus den tmp zu löschen aber das ging nicht mehr mit dem tool.
Deshalb wird überprüft ob eine DB Verbindung existiert, wenn nicht wird ein Hinweis ausgegeben.