### PR TITLE
Fast clear OXID tmp Folder

### DIFF
--- a/src/Oxrun/Command/Cache/ClearCommand.php
+++ b/src/Oxrun/Command/Cache/ClearCommand.php
@@ -5,6 +5,7 @@ namespace Oxrun\Command\Cache;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
 /**
  * Class ClearCommand
@@ -31,18 +32,38 @@ class ClearCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $myConfig = \oxRegistry::getConfig();
-        foreach (glob($myConfig->getConfigParam('sCompileDir') . '/*') as $filename) {
+        $compileDir = $this->getCompileDir();
+        foreach (glob($compileDir . DIRECTORY_SEPARATOR . '*') as $filename) {
             if (!is_dir($filename)) {
                 unlink($filename);
             }
         }
-        foreach (glob($myConfig->getConfigParam('sCompileDir') . '/smarty/*') as $filename) {
+        foreach (glob($compileDir . DIRECTORY_SEPARATOR . 'smarty' . DIRECTORY_SEPARATOR . '*') as $filename) {
             if (!is_dir($filename)) {
                 unlink($filename);
             }
         }
         $output->writeln('<info>Cache cleared.</info>');
+    }
+
+
+
+    /**
+     * Find sCompileDir path without connect to DB.
+     *
+     * @return string
+     */
+    protected function getCompileDir()
+    {
+        $oxidPath = $this->getApplication()->getShopDir();
+        $configfile = $oxidPath . DIRECTORY_SEPARATOR . 'config.inc.php';
+
+        if ($oxidPath && file_exists($configfile)) {
+            $oxConfigFile = new \OxConfigFile($configfile);
+            return $oxConfigFile->getVar('sCompileDir');
+        }
+
+        throw new FileNotFoundException("$configfile");
     }
 
     /**


### PR DESCRIPTION
Wenn die Module Einstellungen in der oxconfig Table mit dem Cache in der tmp/ nicht übereinstimmen. Funktioniert das ganze Framework nicht mehr. (Es bleibt in einer rekursive funktion stecken) Da hilft nur den cache zu löschen. Mit dem Tool ging es dann nicht mehr, weil es eben selber nicht starten konnte.

Das habe ich mit diesem Tool Umschifft und die Profil Lösung eingebaut. Den Ordner zu verschieben und dann erst, den langsamen Prozess anstößt, auf die Platte, die Dateien zu löschen. 