### PR TITLE
Protect clear cache

### DIFF
--- a/src/Oxrun/Command/Cache/ClearCommand.php
+++ b/src/Oxrun/Command/Cache/ClearCommand.php
@@ -121,9 +121,10 @@ class ClearCommand extends Command
     protected function checkSameOwner($compileDir)
     {
         $owner = fileowner($compileDir);
-        $owner = posix_getpwuid($owner);
-        if ($_SERVER['USER'] != $owner['name']) {
+        $current_owner = posix_getuid();
+        if ($current_owner != $owner) {
             global $argv;
+            $owner = posix_getpwuid($owner);
             throw new \Exception("Please run command as `${owner['name']}` user." . PHP_EOL . "    sudo -u ${owner['name']} " . join(' ', $argv));
         }
     }


### PR DESCRIPTION
Habe festgestellt wenn der neue erstellt tmp/ Ordner nicht den gleich user hat wie vorher. Gibt es schreibrechte Probleme. Darum habe ich nochmal einen Schutz vorher eingebaut und mit der Option -force die alte Methode ausgeführt.